### PR TITLE
modify todo policy to treat todos as resources

### DIFF
--- a/content/src/.manifest
+++ b/content/src/.manifest
@@ -1,7 +1,8 @@
 {
   "roots": [
     "policies",
-    "todoApp"
+    "todoApp",
+    "rebac"
   ],
   "metadata": {
     "required_builtins": {

--- a/content/src/policies/rebac.check.rego
+++ b/content/src/policies/rebac.check.rego
@@ -1,0 +1,20 @@
+package rebac.check
+
+# default to a closed system (deny by default)
+default allowed = false
+
+# resource context is expected in the following form:
+# {
+#   "relation": "relation or permission name",
+#   "object_type": "object type that carries the relation or permission",
+#   "object_id": "id of object instance with type of object_type"
+# }
+allowed {
+  ds.check({
+    "object_type": input.resource.object_type,
+    "object_id": input.resource.object_id,
+    "relation": input.resource.relation,
+    "subject_type": "user",
+    "subject_id": input.user.id
+  })
+}

--- a/content/src/policies/todoApp.DELETE.todos.__id.rego
+++ b/content/src/policies/todoApp.DELETE.todos.__id.rego
@@ -12,7 +12,7 @@ default allowed = false
 # check if the user has the can_delete permission on the resource
 # (example of evaluating a permission on a specific resource)
 allowed {
-  check(user, "can_delete", resource.id)
+  check(user, "can_delete", resource.object_id)
 }
 
 # check if the user is a member of the admin group

--- a/content/src/policies/todoApp.DELETE.todos.__id.rego
+++ b/content/src/policies/todoApp.DELETE.todos.__id.rego
@@ -1,17 +1,22 @@
 package todoApp.DELETE.todos.__id
 
+# This policy determines whether the user can delete the todo identified by input.resource.id
+
 import input.user
 import input.resource
-import future.keywords.in
 import data.todoApp.common.is_member_of
+import data.todoApp.common.check
 
 default allowed = false
 
+# check if the user has the can_delete permission on the resource
+# (example of evaluating a permission on a specific resource)
 allowed {
-  is_member_of(user, "editor")
-  user.key == resource.ownerID
+  check(user, "can_delete", resource.id)
 }
 
+# check if the user is a member of the admin group
+# (example of group-based RBAC)
 allowed {
   is_member_of(user, "admin")
 }

--- a/content/src/policies/todoApp.GET.todos.rego
+++ b/content/src/policies/todoApp.GET.todos.rego
@@ -1,3 +1,5 @@
 package todoApp.GET.todos
 
+# This policy determines whether the user can view all todos
+
 default allowed = true

--- a/content/src/policies/todoApp.GET.users.__userID.rego
+++ b/content/src/policies/todoApp.GET.users.__userID.rego
@@ -1,3 +1,5 @@
 package todoApp.GET.users.__userID
 
+# This policy determines whether the user can view a specific user
+
 default allowed = true

--- a/content/src/policies/todoApp.POST.todos.rego
+++ b/content/src/policies/todoApp.POST.todos.rego
@@ -2,16 +2,24 @@ package todoApp.POST.todos
 
 # This policy determines whether the user can create todos
 
-import input.user
-import future.keywords.in
-import data.todoApp.common.is_member_of
-
 default allowed = false
 
-# check if the user is a member of the allowed groups
-# (example of group-based RBAC)
+# Only members of the "resource-creators" instance can create a new Todo.
+#
+# Use the "Check" middleware convention
+# The caller will pass in the following resource context:
+# {
+#   "object_type": "resource-creator",
+#   "object_id": "resource-creators",
+#   "relation": "member"
+# }
+
 allowed {
-  allowedGroups := { "editor", "admin" }
-  some group in allowedGroups
-  is_member_of(user, group)
+  ds.check({
+    "object_type": input.resource.object_type,
+    "object_id": input.resource.object_id,
+    "relation": input.resource.relation,
+    "subject_type": "user",
+    "subject_id": input.user.id
+  })
 }

--- a/content/src/policies/todoApp.POST.todos.rego
+++ b/content/src/policies/todoApp.POST.todos.rego
@@ -1,11 +1,15 @@
 package todoApp.POST.todos
 
+# This policy determines whether the user can create todos
+
 import input.user
 import future.keywords.in
 import data.todoApp.common.is_member_of
 
 default allowed = false
 
+# check if the user is a member of the allowed groups
+# (example of group-based RBAC)
 allowed {
   allowedGroups := { "editor", "admin" }
   some group in allowedGroups

--- a/content/src/policies/todoApp.PUT.todos.__id.rego
+++ b/content/src/policies/todoApp.PUT.todos.__id.rego
@@ -1,17 +1,25 @@
 package todoApp.PUT.todos.__id
 
+# This policy determines whether the user can complete a specific todo identified by input.resource.id
+
 import input.user
 import input.resource
 import future.keywords.in
 import data.todoApp.common.is_member_of
+import data.todoApp.common.check
 
 default allowed = false
 
+# check if the user has the can_write permission on the resource
+# (example of evaluating a permission on a specific resource)
 allowed {
-  is_member_of(user, "editor")
-  user.key == resource.ownerID
+  check(user, "can_write", resource.id)
 }
 
+# check if the user is a member of the allowed groups
+# (example of group-based RBAC)
 allowed {
-  is_member_of(user, "evil_genius")
+  allowedGroups := { "admin", "evil_genius" }
+  some group in allowedGroups
+  is_member_of(user, group)
 }

--- a/content/src/policies/todoApp.PUT.todos.__id.rego
+++ b/content/src/policies/todoApp.PUT.todos.__id.rego
@@ -13,7 +13,7 @@ default allowed = false
 # check if the user has the can_write permission on the resource
 # (example of evaluating a permission on a specific resource)
 allowed {
-  check(user, "can_write", resource.id)
+  check(user, "can_write", resource.object_id)
 }
 
 # check if the user is a member of the allowed groups

--- a/content/src/policies/todoApp.common.rego
+++ b/content/src/policies/todoApp.common.rego
@@ -1,18 +1,21 @@
 package todoApp.common
 
 is_member_of(user, group) := x {
-  x := ds.check_relation({
-    "object": {
-      "key": group,
-      "type": "group"
-    },
-    "relation": {
-      "name": "member",
-      "object_type": "group"
-    },
-    "subject": {
-      "key": user.key,
-      "type": "user"
-    }
+  x := ds.check({
+    "object_id": group,
+    "object_type": "group",
+    "relation": "member",
+    "subject_id": user.id,
+    "subject_type": "user"
+  })
+}
+
+check(user, permission, todo) := x {
+  x := ds.check({
+    "object_id": todo,
+    "object_type": "resource",
+    "relation": permission,
+    "subject_id": user.id,
+    "subject_type": "user"
   })
 }


### PR DESCRIPTION
This PR relies on `ds.check` to determine whether a user has the `can_write` / `can_delete` permissions on a todo. 